### PR TITLE
Cryptography removed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ numpy
 scipy 
 pyserial 
 xlsxwriter 
-cryptography 
 pyasn1 
 autobahn  
 pylint

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name="congo-lab",
-    version="0.6",
+    version="0.7",
     author="Richard Ingham, Gary Short",
     description="Real-time laboratory automation and monitoring in Python.",
     long_description=long_description,


### PR DESCRIPTION
1. Can't be built on 386 and don't think the package is required.
2. Version bumped

Closes #8 